### PR TITLE
Add version tag to compose yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+version: "2"
 services:
   stationeers:
     image: hetsh/stationeers


### PR DESCRIPTION
This is necessary with newer versions of docker-compose, as the "services" tag is a version 2 feature